### PR TITLE
Fix params error when using dynamic routes

### DIFF
--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -16,8 +16,8 @@ function objectValues(obj) {
 function getURL(routing, transition) {
     let params = [];
 
-    if (transition.params) {
-        params = objectValues(transition.params).filter(param => {
+    if (transition.to.params) {
+        params = objectValues(transition.to.params).filter(param => {
           return objectValues(param).length;
         });
     }
@@ -44,7 +44,7 @@ export default Mixin.create({
         if (initial) {
             const handlerInfos = transition.routeInfos;
             const parentRoute = handlerInfos[handlerInfos.length - 2].name;
-            
+
             this.transitionTo(parentRoute).method(false).then(() => {
                 transition.retry();
             });


### PR DESCRIPTION
If in use with dynamic routes (in this case 'resource-analysis' is the routable modal):

router.js:
```
Router.map(function() {
  this.route('dashboard', {path:'/'}, function() {
    this.route('resource-analysis', { path: '/resource-analysis/:process_step_id' });
  });
});
```

template:
```
<LinkTo @route="dashboard.resource-analysis" @model={{this.processStep.id}}>Foo</LinkTo>
```

route:
```
  model(params) {
    console.log(params.process_step_id)
  }
```

I got the following error:

```
Error while processing route: dashboard.resource-analysis You must provide param `process_step_id` to `generate`. Error: You must provide param `process_step_id` to `generate`.
```

This was caused because apparently ember moved the params to the transition.to object and should be fixed with this PR.